### PR TITLE
Feature/7

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,8 @@
 podman run --name devnet1 ghcr.io/grzegorznowak/cardano-devnet:1.33.0
 
 # wait for "Congrats! Your network is ready for use!"
-# your devnet is now running in the devnet1 container
 
 # === in A NEW TERMINAL ===
-# confirm the container process is running 
-podman ps list
-
 # interact with the blockchain from the shell
 podman exec devnet1 cardano-cli query utxo --whole-utxo --testnet-magic 42
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,33 @@
 # cardano-private-testnet-setup
 
-## Quickstart
+## Quickstart using containers
 
 ```
-[clone the repo - or pull a stable dist]
-[instruction on how to start the devnet container]
-[basic interaction instructions]
-[references to full-on README bits with details]
+# install podman https://podman.io/getting-started/installation
+
+# then execute
+podman run --name devnet1 ghcr.io/grzegorznowak/cardano-devnet:1.33.0
+
+# wait for "Congrats! Your network is ready for use!"
+# your devnet is now running in the devnet1 container
+
+# === in A NEW TERMINAL ===
+# confirm the container process is running 
+podman ps list
+
+# interact with the blockchain from the shell
+podman exec devnet1 cardano-cli query utxo --whole-utxo --testnet-magic 42
+
+# or just own the devnet1's bash 
+podman exec -it devnet1 bash
+
+# and operate on it directly from within
+cardano-cli query utxo --address $(~/cardano_devnet/private-testnet/addresses/user1.addr) --testnet-magic 42
+
+# a killed devnet1 blockchain can be revived with
+podman start devnet1
+
+# create as many devnetX container, tweak, adjust to taste and prosper 
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ podman exec devnet1 cardano-cli query utxo --whole-utxo --testnet-magic 42
 podman exec -it devnet1 bash
 
 # and operate on it directly from within
-cardano-cli query utxo --address $(~/cardano_devnet/private-testnet/addresses/user1.addr) --testnet-magic 42
+cardano-cli query utxo \
+--address $(~/cardano_devnet/private-testnet/addresses/user1.addr) \
+--testnet-magic 42
 
 # a killed devnet1 blockchain can be revived with
 podman start devnet1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # cardano-private-testnet-setup
 
+## Quickstart
+
+```
+[clone the repo - or pull a stable dist]
+[instruction on how to start the devnet container]
+[basic interaction instructions]
+[references to full-on README bits with details]
+```
+
 ---
 
 This project provides instructions and shell scripts to bootstrap a private Cardano testnet and connect a `cardano-db-sync` process to it.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ podman exec -it devnet1 bash
 
 # and operate on it directly from within
 cardano-cli query utxo \
---address $(~/cardano_devnet/private-testnet/addresses/user1.addr) \
+--address $(cat ~/cardano_devnet/private-testnet/addresses/user1.addr) \
 --testnet-magic 42
 
 # a killed devnet1 blockchain can be revived with

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cardano-private-testnet-setup
+# Cardano Private-Testnet / Devnet Setup
 
 ## Quickstart using containers
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cardano-cli query utxo --address $(~/cardano_devnet/private-testnet/addresses/us
 # a killed devnet1 blockchain can be revived with
 podman start devnet1
 
-# create as many devnetX container, tweak, adjust to taste and prosper 
+# create as many devnetX containers as you need, tweak, adjust to taste and prosper 
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -1,33 +1,5 @@
 # Cardano Private-Testnet / Devnet Setup
 
-## Quickstart using containers
-
-```
-# install podman https://podman.io/getting-started/installation
-
-# then execute
-podman run --name devnet1 ghcr.io/grzegorznowak/cardano-devnet:1.33.0
-
-# wait for "Congrats! Your network is ready for use!"
-
-# === in A NEW TERMINAL ===
-# interact with the blockchain from the shell
-podman exec devnet1 cardano-cli query utxo --whole-utxo --testnet-magic 42
-
-# or just own the devnet1's bash 
-podman exec -it devnet1 bash
-
-# and operate on it directly from within
-cardano-cli query utxo \
---address $(cat ~/cardano_devnet/private-testnet/addresses/user1.addr) \
---testnet-magic 42
-
-# a killed devnet1 blockchain can be revived with
-podman start devnet1
-
-# create as many devnetX containers as you need, tweak, adjust to taste and prosper 
-```
-
 ---
 
 This project provides instructions and shell scripts to bootstrap a private Cardano testnet and connect a `cardano-db-sync` process to it.

--- a/scripts/automate.sh
+++ b/scripts/automate.sh
@@ -36,7 +36,7 @@ kill_running_nodes() {
 
 start_all_nodes() {
   echo "start all the nodes in bg"
-  $ROOT/run/all.sh > /dev/null 2>&1 &
+  nohup $ROOT/run/all.sh > /dev/null 2>&1 &
   wait_until_count_of_running_nodes 3
   echo
   echo "PIDs of started nodes:"
@@ -106,5 +106,3 @@ protocol_version=$( cardano-cli query protocol-parameters --testnet-magic 42 | j
 echo "Nodes are running in era: $current_era, major protocol version: $protocol_version"
 echo
 echo "Congrats! Your network is ready for use!"
-
-wait

--- a/scripts/automate.sh
+++ b/scripts/automate.sh
@@ -86,20 +86,20 @@ if [ $running_nodes_cnt -gt 0 ]; then
   exit
 fi
 
-
-# delete root folder to get clean slate only if we didn't ask it not to do that
-# invoke as `./automate 1` to effectively stop flushing the underlying private blockchain
-[[ $2 != "1" ]] && rm -rf $ROOT
-
 # run script to create config
 "${SCRIPT_PATH}"/mkfiles.sh alonzo
 
-echo
 restart_nodes_in_bg
-
 echo
 wait_until_socket_detected
-run_update_script "1"
+
+if [ -d $ROOT ]; then
+  echo "existing blockchain data found, skipping the update script"
+else
+  echo "bootstrapping into the pristine state; consuming the genesis utxo"
+  run_update_script "1"
+fi
+
 
 query_tip
 echo

--- a/scripts/automate.sh
+++ b/scripts/automate.sh
@@ -86,6 +86,10 @@ if [ $running_nodes_cnt -gt 0 ]; then
   exit
 fi
 
+# delete root folder to get clean slate only if we didn't ask it not to do that
+# invoke as `./automate 1` to effectively stop flushing the underlying private blockchain
+[[ $2 != "1" ]] && rm -rf $ROOT
+
 # run script to create config
 "${SCRIPT_PATH}"/mkfiles.sh alonzo
 

--- a/scripts/automate.sh
+++ b/scripts/automate.sh
@@ -86,8 +86,10 @@ if [ $running_nodes_cnt -gt 0 ]; then
   exit
 fi
 
-# delete root folder to get clean slate
-rm -rf $ROOT
+
+# delete root folder to get clean slate only if we didn't ask it not to do that
+# invoke as `./automate 1` to effectively stop flushing the underlying private blockchain
+[[ $2 != "1" ]] && rm -rf $ROOT
 
 # run script to create config
 "${SCRIPT_PATH}"/mkfiles.sh alonzo

--- a/scripts/automate.sh
+++ b/scripts/automate.sh
@@ -36,7 +36,7 @@ kill_running_nodes() {
 
 start_all_nodes() {
   echo "start all the nodes in bg"
-  nohup $ROOT/run/all.sh > /dev/null 2>&1 &
+  $ROOT/run/all.sh > /dev/null 2>&1 &
   wait_until_count_of_running_nodes 3
   echo
   echo "PIDs of started nodes:"
@@ -106,3 +106,5 @@ protocol_version=$( cardano-cli query protocol-parameters --testnet-magic 42 | j
 echo "Nodes are running in era: $current_era, major protocol version: $protocol_version"
 echo
 echo "Congrats! Your network is ready for use!"
+
+wait


### PR DESCRIPTION
have removed the podman-heave quickstart section as we briefly discussed via Discord, so the only real change is ability to not remove the whole blockchain data during subsequent `automate.sh` calls, when a parameter is given. The default behaviour is to remove, so should be transparent for existing users.

the question now is where to put the link to the podman quickstart in the other repo. Let me know pls.