### PR TITLE
Kurt/restore db sync instructions

### DIFF
--- a/1-INSTALL_EXECUTABLES.md
+++ b/1-INSTALL_EXECUTABLES.md
@@ -33,65 +33,40 @@ from Haskell sources. **You may skip the rest of this readme, if db-sync is not 
 ## Optional: Building cardano-db-sync from Haskell sources using cabal and GHC
 
 ### 1. Install package dependencies and Haskell tooling
-
 - Install package dependencies of tools
-
   ```shell
-
   # update/upgrade your package indexes
-
   sudo apt-get update
-
   sudo apt-get upgrade  
-
   # reboot as necessary
-    
   sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf -y  
-
   ```
 
 - Install Cabal and GHC using [GHCUp - Haskell language installer](https://www.haskell.org/ghcup/)
-
   ```shell
-
   # download and run get-ghcup script
-
   curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-
   # During questions, I chose to (A)ppend the path to ghc to .bashrc
-
   # and did not choose to install Haskell Language Server (HLS) or stack
-
   # source the bash start script to apply updates to PATH
-
   cd $HOME
-
   source .bashrc
   
   # get the latest updates to GHCUp tool
-
   ghcup upgrade
 
   # install cabal with GHCUp 
-
   ghcup install cabal 3.6.2.0
-
   ghcup set cabal 3.6.2.0
 
   # install GHC with GHCUp
-
   ghcup install ghc 8.10.7
-
   ghcup set ghc 8.10.7
   
   # Update cabal and verify the correct versions were installed successfully.
-
   cabal update
-
   cabal --version
-
   ghc --version
-
   ```
 
 ### 2. Install latest release tags of Cardano db-sync executables including some patches necessary to make things work in private testnet  
@@ -105,19 +80,13 @@ please see the [IOHK cardano-db-sync README](https://github.com/input-output-hk/
 to work with a private testnet.  If you want to understand the issue, please visit: [issue](https://github.com/input-output-hk/cardano-db-sync/issues/1046). 
 
 - Clone the IOHK cardano-db-sync repo
-
   ```shell
-
   cd $HOME/src
-
   git clone https://github.com/input-output-hk/cardano-db-sync
-
   cd cardano-db-sync  
-
   # fetch the list of tags and check out the latest release tag name  
-
   git fetch --tags --all
-
+  
   # checkout the latest release (currently 12.0.2 as of 3/27/22) of db-sync
   git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-db-sync/releases/latest | jq -r .tag_name)
 
@@ -128,7 +97,6 @@ to work with a private testnet.  If you want to understand the issue, please vis
 
   # cherry-pick #2 - change to Block.hs
   git cherry-pick -n 132f569bcd297ce73bca407a52acee513aa75389
-
   ```
 
 - Fetch postgres `libpq-dev` package, update dependencies and build the cardano-db-sync project.  This can take 20 minutes+
@@ -138,35 +106,23 @@ to work with a private testnet.  If you want to understand the issue, please vis
   ```shell
 
   sudo apt-get install libpq-dev
-
   cabal update
 
+  # build cardano-db-sync executables
   cabal build all
-
   ```
 
 - Copy db-sync executables to local user default path location
-
   ```shell
-
   cp -p $(find dist-newstyle/build -type f -name "cardano-db-sync") $HOME/.local/bin/cardano-db-sync
-
   cp -p $(find dist-newstyle/build -type f -name "cardano-db-sync-extended") $HOME/.local/bin/cardano-db-sync-extended  
-
   ```
 
 - Verify the versions of the db-sync executables
-
   ```shell
-
   cardano-db-sync --version
-
   cardano-db-sync-extended --version
-  
   # when this document was written, the current version for each is 12.0.2 on linux-x86_64
-
   ```
-
 ---
-
 Continue to next guide: [2. Install PostgreSQL instructions](./2-INSTALL_POSTGRESQL.md)

--- a/1-INSTALL_EXECUTABLES.md
+++ b/1-INSTALL_EXECUTABLES.md
@@ -20,144 +20,153 @@ This guide covers installing `cardano-node`, `cardano-cli` and optionally `carda
 Continue to guide: [3. Run Network Scripts](./3-RUN_NETWORK_SCRIPTS.md)
 
 
-[comment]: <> (If you don't plan on using `cardano-db-sync`, you can continue to guide: [3. Run Network Scripts]&#40;./3-RUN_NETWORK_SCRIPTS.md&#41;.)
+If you don't plan on using `cardano-db-sync`, you can continue to guide: [3. Run Network Scripts](./3-RUN_NETWORK_SCRIPTS.md).
 
-[comment]: <> (Otherwise, continue following the directions below.)
+Otherwise, continue following the directions below.
 
-[comment]: <> (***)
+***
 
-[comment]: <> (**Note**: The remainder of this guide covers how to build all the executables including the `cardano-db-sync` executables)
+**Note**: The remainder of this guide covers how to build all the executables including the `cardano-db-sync` executables
 
-[comment]: <> (from Haskell sources. **You may skip the rest of this readme, if db-sync is not relevant to you.**)
+from Haskell sources. **You may skip the rest of this readme, if db-sync is not relevant to you.**
 
-[comment]: <> (## Optional: Building cardano-db-sync from Haskell sources using cabal and GHC)
+## Optional: Building cardano-db-sync from Haskell sources using cabal and GHC
 
-[comment]: <> (### 1. Install package dependencies and Haskell tooling)
+### 1. Install package dependencies and Haskell tooling
 
-[comment]: <> (- Install package dependencies of tools)
+- Install package dependencies of tools
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  # update/upgrade your package indexes)
+  # update/upgrade your package indexes
 
-[comment]: <> (  sudo apt-get update)
+  sudo apt-get update
 
-[comment]: <> (  sudo apt-get upgrade  )
+  sudo apt-get upgrade  
 
-[comment]: <> (  # reboot as necessary)
+  # reboot as necessary
     
-[comment]: <> (  sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf -y  )
+  sudo apt-get install automake build-essential pkg-config libffi-dev libgmp-dev libssl-dev libtinfo-dev libsystemd-dev zlib1g-dev make g++ tmux git jq wget libncursesw5 libtool autoconf -y  
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (- Install Cabal and GHC using [GHCUp - Haskell language installer]&#40;https://www.haskell.org/ghcup/&#41;)
+- Install Cabal and GHC using [GHCUp - Haskell language installer](https://www.haskell.org/ghcup/)
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  # download and run get-ghcup script)
+  # download and run get-ghcup script
 
-[comment]: <> (  curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh)
+  curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 
-[comment]: <> (  # During questions, I chose to &#40;A&#41;ppend the path to ghc to .bashrc)
+  # During questions, I chose to (A)ppend the path to ghc to .bashrc
 
-[comment]: <> (  # and did not choose to install Haskell Language Server &#40;HLS&#41; or stack)
+  # and did not choose to install Haskell Language Server (HLS) or stack
 
-[comment]: <> (  # source the bash start script to apply updates to PATH)
+  # source the bash start script to apply updates to PATH
 
-[comment]: <> (  cd $HOME)
+  cd $HOME
 
-[comment]: <> (  source .bashrc)
+  source .bashrc
   
-[comment]: <> (  # get the latest updates to GHCUp tool)
+  # get the latest updates to GHCUp tool
 
-[comment]: <> (  ghcup upgrade)
+  ghcup upgrade
 
-[comment]: <> (  # install cabal with GHCUp )
+  # install cabal with GHCUp 
 
-[comment]: <> (  ghcup install cabal 3.4.0.0)
+  ghcup install cabal 3.6.2.0
 
-[comment]: <> (  ghcup set cabal 3.4.0.0)
+  ghcup set cabal 3.6.2.0
 
-[comment]: <> (  # install GHC with GHCUp)
+  # install GHC with GHCUp
 
-[comment]: <> (  ghcup install ghc 8.10.4)
+  ghcup install ghc 8.10.7
 
-[comment]: <> (  ghcup set ghc 8.10.4)
+  ghcup set ghc 8.10.7
   
-[comment]: <> (  # Update cabal and verify the correct versions were installed successfully.)
+  # Update cabal and verify the correct versions were installed successfully.
 
-[comment]: <> (  cabal update)
+  cabal update
 
-[comment]: <> (  cabal --version)
+  cabal --version
 
-[comment]: <> (  ghc --version)
+  ghc --version
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (### 2. Install latest release tags of Cardano db-sync executables )
+### 2. Install latest release tags of Cardano db-sync executables including some patches necessary to make things work in private testnet  
 
-[comment]: <> (**Note**: The author could not find pre-built binaries for cardano-db-sync from IOHK, so the directions below)
+**Note**: The author could not find pre-built binaries for cardano-db-sync from IOHK, so the directions below
+are to build them from Haskell sources using cabal and GHC.  If you want to explore other options to build
+or deploy, e.g. using `nix-build` or `docker`,
+please see the [IOHK cardano-db-sync README](https://github.com/input-output-hk/cardano-db-sync#readme) for more info.
 
-[comment]: <> (are to build them from Haskell sources using cabal and GHC.  If you want to explore other options to build)
+**Note2**: The directions below include applying some cherry-pick commits, which are necessary to allow `cardano-db-sync`
+to work with a private testnet.  If you want to understand the issue, please visit: [issue](https://github.com/input-output-hk/cardano-db-sync/issues/1046). 
 
-[comment]: <> (or deploy, e.g. using `nix-build` or `docker`, )
+- Clone the IOHK cardano-db-sync repo
 
-[comment]: <> (please see the [IOHK cardano-db-sync README]&#40;https://github.com/input-output-hk/cardano-db-sync#readme&#41; for more info.)
+  ```shell
 
-[comment]: <> (- Clone the IOHK cardano-db-sync repo)
+  cd $HOME/src
 
-[comment]: <> (  ```shell)
+  git clone https://github.com/input-output-hk/cardano-db-sync
 
-[comment]: <> (  cd $HOME/src)
+  cd cardano-db-sync  
 
-[comment]: <> (  git clone https://github.com/input-output-hk/cardano-db-sync)
+  # fetch the list of tags and check out the latest release tag name  
 
-[comment]: <> (  cd cardano-db-sync  )
+  git fetch --tags --all
 
-[comment]: <> (  # fetch the list of tags and check out the latest release tag name  )
+  # checkout the latest release (currently 12.0.2 as of 3/27/22) of db-sync
+  git checkout $(curl -s https://api.github.com/repos/input-output-hk/cardano-db-sync/releases/latest | jq -r .tag_name)
 
-[comment]: <> (  git fetch --tags --all)
+  # cherry pick the following 2 commits (using -n to avoid auto committing into local git repo)
 
-[comment]: <> (  git checkout $&#40;curl -s https://api.github.com/repos/input-output-hk/cardano-db-sync/releases/latest | jq -r .tag_name&#41;)
+  # cherry-pick #1 - change to Genesis.hs
+  git cherry-pick -n bff6e182cf41f6f7a9ff3d08bb1fc9984e2d0f66
 
-[comment]: <> (  ```)
+  # cherry-pick #2 - change to Block.hs
+  git cherry-pick -n 132f569bcd297ce73bca407a52acee513aa75389
 
-[comment]: <> (- Fetch postgres `libpq-dev` package, update dependencies and build the cardano-db-sync project.  This can take 20 minutes+)
+  ```
+
+- Fetch postgres `libpq-dev` package, update dependencies and build the cardano-db-sync project.  This can take 20 minutes+
   
-[comment]: <> (  **Note**: Building `cardano-db-sync` project from source, depends on finding the postgres `libpq-dev` package on the host OS.)
+  **Note**: Building `cardano-db-sync` project from source, depends on finding the postgres `libpq-dev` package on the host OS.
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  sudo apt-get install libpq-dev)
+  sudo apt-get install libpq-dev
 
-[comment]: <> (  cabal update)
+  cabal update
 
-[comment]: <> (  cabal build all)
+  cabal build all
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (- Copy db-sync executables to local user default path location)
+- Copy db-sync executables to local user default path location
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  cp -p $&#40;find dist-newstyle/build -type f -name "cardano-db-sync"&#41; $HOME/.local/bin/cardano-db-sync)
+  cp -p $(find dist-newstyle/build -type f -name "cardano-db-sync") $HOME/.local/bin/cardano-db-sync
 
-[comment]: <> (  cp -p $&#40;find dist-newstyle/build -type f -name "cardano-db-sync-extended"&#41; $HOME/.local/bin/cardano-db-sync-extended  )
+  cp -p $(find dist-newstyle/build -type f -name "cardano-db-sync-extended") $HOME/.local/bin/cardano-db-sync-extended  
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (- Verify the versions of the db-sync executables)
+- Verify the versions of the db-sync executables
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  cardano-db-sync --version)
+  cardano-db-sync --version
 
-[comment]: <> (  cardano-db-sync-extended --version)
+  cardano-db-sync-extended --version
   
-[comment]: <> (  # when this document was written, the current version for each is 12.0.0 on linux-x86_64)
+  # when this document was written, the current version for each is 12.0.2 on linux-x86_64
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (---)
+---
 
-[comment]: <> (Continue to next guide: [2. Install PostgreSQL instructions]&#40;./2-INSTALL_POSTGRESQL.md&#41;)
+Continue to next guide: [2. Install PostgreSQL instructions](./2-INSTALL_POSTGRESQL.md)

--- a/1-INSTALL_EXECUTABLES.md
+++ b/1-INSTALL_EXECUTABLES.md
@@ -26,8 +26,7 @@ Otherwise, continue following the directions below.
 
 ***
 
-**Note**: The remainder of this guide covers how to build all the executables including the `cardano-db-sync` executables
-
+**Note**: The remainder of this guide covers how to build the `cardano-db-sync` executables
 from Haskell sources. **You may skip the rest of this readme, if db-sync is not relevant to you.**
 
 ## Optional: Building cardano-db-sync from Haskell sources using cabal and GHC
@@ -71,13 +70,12 @@ from Haskell sources. **You may skip the rest of this readme, if db-sync is not 
 
 ### 2. Install latest release tags of Cardano db-sync executables including some patches necessary to make things work in private testnet  
 
-**Note**: The author could not find pre-built binaries for cardano-db-sync from IOHK, so the directions below
-are to build them from Haskell sources using cabal and GHC.  If you want to explore other options to build
+**Note**: The directions below are to build `cardano-db-sync` from Haskell sources using cabal and GHC.  If you want to explore other options to build
 or deploy, e.g. using `nix-build` or `docker`,
 please see the [IOHK cardano-db-sync README](https://github.com/input-output-hk/cardano-db-sync#readme) for more info.
 
 **Note2**: The directions below include applying some cherry-pick commits, which are necessary to allow `cardano-db-sync`
-to work with a private testnet.  If you want to understand the issue, please visit: [issue](https://github.com/input-output-hk/cardano-db-sync/issues/1046). 
+to work with a private testnet. If you want to understand the issue, please visit: [issue](https://github.com/input-output-hk/cardano-db-sync/issues/1046). 
 
 - Clone the IOHK cardano-db-sync repo
   ```shell

--- a/2-INSTALL_POSTGRESQL.md
+++ b/2-INSTALL_POSTGRESQL.md
@@ -1,106 +1,99 @@
 # Install PostgreSQL and create user
+**Note**: If you have not installed `cardano-db-sync`, then you should skip this guide and continue to next guide: [3. Run scripts](3-RUN_NETWORK_SCRIPTS.md)
 
-## Note: Please skip running this guide until an issue is fixed
+This document explains how to install PostgreSQL and create a Postgres user.
 
-A recent change to the `cardano-db-sync` project source code leads to a validation failure when trying to
-attach the db-sync process to the private testnet. The author has logged an issue to find out how to resolve:
-[logged cardano-db-sync issue](https://github.com/input-output-hk/cardano-db-sync/issues/1046).
+#### Assumptions
 
-[comment]: <> (**Note**: If you have not installed `cardano-db-sync`, then you should skip this guide and continue to next guide: [3. Run scripts]&#40;3-RUN_NETWORK_SCRIPTS.md&#41;)
+- This guide assumes you are running a recent version of linux. 
 
-[comment]: <> (This document explains how to install PostgreSQL and create a Postgres user.)
-
-[comment]: <> (#### Assumptions)
-
-[comment]: <> (- This guide assumes you are running a recent version of linux. )
-
-[comment]: <> (  Specifically, these directions apply to Ubuntu &#40;Debian&#41;. If you are using a different linux variant, please adjust as needed)
+  Specifically, these directions apply to Ubuntu (Debian). If you are using a different linux variant, please adjust as needed
    
 
-[comment]: <> (## 1. Install PostgreSQL)
+## 1. Install PostgreSQL
  
-[comment]: <> (- Update/upgrade your package indexes)
+- Update/upgrade your package indexes
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  sudo apt-get update)
+  sudo apt-get update
 
-[comment]: <> (  sudo apt-get upgrade)
+  sudo apt-get upgrade
 
-[comment]: <> (  # reboot as necessary  )
+  # reboot as necessary  
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (- Install postgreSQL packages)
+- Install postgreSQL packages
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  sudo apt-get install postgresql postgresql-contrib)
+  sudo apt-get install postgresql postgresql-contrib
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (- Verify postgres is installed by starting a postgres sql session in the terminal)
+- Verify postgres is installed by starting a postgres sql session in the terminal
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  sudo -u postgres psql)
+  sudo -u postgres psql
   
-[comment]: <> (  # you should see prompt)
+  # you should see prompt
 
-[comment]: <> (  # postgres=#)
+  # postgres=#
   
-[comment]: <> (  # to exit the session )
+  # to exit the session 
 
-[comment]: <> (  \q)
+  \q
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (## 2. Create new Postgres role for your linux user account)
+## 2. Create new Postgres role for your linux user account
 
-[comment]: <> (- Upon installation, Postgres is set up to use `ident authentication`, )
+- Upon installation, Postgres is set up to use `ident authentication`, 
 
-[comment]: <> (  meaning that it associates Postgres roles with a matching Unix/Linux system account. )
+  meaning that it associates Postgres roles with a matching Unix/Linux system account. 
 
-[comment]: <> (  If a role exists within Postgres, a Unix/Linux username with the same name is able to sign in as that role.)
+  If a role exists within Postgres, a Unix/Linux username with the same name is able to sign in as that role.
 
-[comment]: <> (  - Additional background documentation: [Postgresql Ident Authentication]&#40;https://www.postgresql.org/docs/current/auth-ident.html&#41;  )
+  - Additional background documentation: [Postgresql Ident Authentication](https://www.postgresql.org/docs/current/auth-ident.html)  
     
-[comment]: <> (- Create a user for your local linux user account and give it superuser role.   Our user must be a superuser in order to create/drop databases, etc.)
+- Create a user for your local linux user account and give it superuser role.   Our user must be a superuser in order to create/drop databases, etc.
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  sudo -u postgres createuser --interactive)
+  sudo -u postgres createuser --interactive
   
-[comment]: <> (  # enter your linux user account)
+  # enter your linux user account
 
-[comment]: <> (  Enter name of role to add: <your_linux_user_account_name>)
+  Enter name of role to add: <your_linux_user_account_name>
 
-[comment]: <> (  Shall the new role be a superuser? &#40;y/n&#41; y)
+  Shall the new role be a superuser? (y/n) y
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (- Verify your local account got created)
+- Verify your local account got created
 
-[comment]: <> (  ```shell)
+  ```shell
 
-[comment]: <> (  sudo -u postgres psql)
+  sudo -u postgres psql
   
-[comment]: <> (  # you should see prompt)
+  # you should see prompt
 
-[comment]: <> (  # postgres=#)
+  # postgres=#
   
-[comment]: <> (  # to display users )
+  # to display users 
 
-[comment]: <> (  \du)
+  \du
   
-[comment]: <> (  # you should see a role name of your linux account with Superuser role attribute)
+  # you should see a role name of your linux account with Superuser role attribute
   
-[comment]: <> (  # to exit the session )
+  # to exit the session 
 
-[comment]: <> (  \q)
+  \q
 
-[comment]: <> (  ```)
+  ```
 
-[comment]: <> (---)
+---
 
-[comment]: <> (Continue to next guide: [3. Run scripts]&#40;3-RUN_NETWORK_SCRIPTS.md&#41;)
+Continue to next guide: [3. Run scripts](3-RUN_NETWORK_SCRIPTS.md)

--- a/3-RUN_NETWORK_SCRIPTS.md
+++ b/3-RUN_NETWORK_SCRIPTS.md
@@ -24,7 +24,7 @@ After creating the configuration data, the script starts up the nodes and fires 
 genesis funds to the user1 wallet address.
 
 Once you have completed this step, the `private-testnet` will be running in the `alonzo` era and the user1 wallet address
-has some `utxos` to use for doing transactions.
+has some `UTxOs` to use for doing transactions.
 
 #### Directions
 - Adjust the [config.cfg file](./scripts/config.cfg) as desired. By default, the ROOT directory is set to `private-network`

--- a/3-RUN_NETWORK_SCRIPTS.md
+++ b/3-RUN_NETWORK_SCRIPTS.md
@@ -1,19 +1,12 @@
-# Run scripts to start private testnet
+# Run script to start private testnet
 
 **Now, we get to the fun part!**  We are ready to create & start a private Cardano testnet.
 The testnet will run three block producer nodes. 
-After starting the testnet and running all protocol updates, we set up a PostgreSQL database for cardano-db-sync.
-Then, we connect the db-sync process to one of the cardano nodes, so that
-it can synchronize to the activity occurring on our testnet and write data to its database.
-
-**Tip**: The instructions below require opening several terminal- windows or tabs.  You might prefer creating a [`tmux`](https://en.wikipedia.org/wiki/Tmux) session
-and create several window panes in your session to make it easier to see everything in the same terminal window.
 
 #### Assumptions
 - This guide assumes you are running a recent version of linux.
   Specifically, these directions apply to Ubuntu (Debian). If you are using a different linux variant, please adjust as needed
-- Before using this guide, you should have completed the [Install executables guide](./1-INSTALL_EXECUTABLES.md) and
-  [Install PostgreSQL guide](2-INSTALL_POSTGRESQL.md).
+- Before using this guide, you should have completed the [Install executables guide](./1-INSTALL_EXECUTABLES.md). 
   
 ## 1. Clone this project
 
@@ -23,166 +16,42 @@ and create several window panes in your session to make it easier to see everyth
   git clone https://github.com/woofpool/cardano-private-testnet-setup
   ```
 
-## 2. Bootstrap the network and apply protocol updates
+## 2. Run automate script to bootstrap the network
 
-At the time of this writing, the current era is `alonzo` and major protocol version `6`.
-After we bootstrap the network in the `Byron` era/major protocol version `0`, the update scripts are applied 
-one by one to advance the network into the current era and major protocol version.
-In order to advance the protocol version, it requires two transactions-- 1) update proposal transaction and a 2) vote transaction.
-After a protocol update has been staged, we need to wait an epoch
-before the protocol version is bumped in the protocol parameters. It takes around 3 to 5 minutes for an epoch to complete based
-on the testnet environment configuration.
+In this step, we run the `automate.sh` script.  This script will set up the necessary configuration files
+for three block-producing nodes. The configuration data is compatible with the `alonzo` era.  
+After creating the configuration data, the script starts up the nodes and fires an `update-1.sh` script to run a transaction that sends
+genesis funds to the user1 wallet address.
 
-Whether you run the process manually or use the automated script, it will take about 20-25 minutes to apply all the updates.
-By running the process manually, you get to experience the update process in a similar way to how things happen in mainnet Cardano.
-On the other hand, you can also run the `automate.sh` script to process things without needing to babysit the process.
-
-Once you have completed this step, the `private-testnet` folder contains the persisted blockchain data,
-which means you can restart the nodes whenever you like, and your private testnet will be running in the current era and protocol.
+Once you have completed this step, the `private-testnet` will be running in the `alonzo` era and the user1 wallet address
+has some `utxos` to use for doing transactions.
 
 #### Directions
 - Adjust the [config.cfg file](./scripts/config.cfg) as desired. By default, the ROOT directory is set to `private-network`
-- Choose **Option 1** to run a single script that automates the whole process or choose **Option 2** to run the scripts manually
-  #### Option 1: Run automated script
-    - In **terminal #1**, run the automate script. This script simply automates the process to run the sequence of steps described in Option 2.
-      It takes about 20-25 minutes to complete.
-      ```shell
-      # navigate to project root folder
-      cd $HOME/src/cardano-private-testnet-setup
-      ./scripts/automate.sh
+- In **terminal #1**, run the automate script.
+  It takes less than a minute to fire up the network.
+  ```shell
+  # navigate to project root folder
+  cd $HOME/src/cardano-private-testnet-setup
+  ./scripts/automate.sh
       
-      # if you receive an error about "running nodes found", you will need to kill cardano node processes
-      # and run the automate.sh script again
+  # if you receive an error about "running nodes found", you will need to kill cardano node processes
+  # and run the automate.sh script again
       
-      # when the script completes successfully, it will show the current era and major protocol version
-      # the last command that runs in the script is `wait`
-      # If you kill the script, that will also kill the running nodes.
-      ```
-    - In **terminal #2**, you can tail the log to monitor the activity occurring in the nodes
-      ```shell
-      # navigate to project root folder
-      cd $HOME/src/cardano-private-testnet-setup
-      tail -f logs/privatenet.log
-      ```
+  # when the script completes successfully, it will show the current era and major protocol version
+  # the last command that runs in the script is `wait`
+  # If you kill the script, that will also kill the running nodes.
+  ```
+  - In **terminal #2**, you can tail the log to monitor the activity occurring in the nodes
+  ```shell
+  # navigate to project root folder
+  cd $HOME/src/cardano-private-testnet-setup
+  tail -f logs/privatenet.log
+  ```
 
-  #### Option 2: Run sequence of scripts manually
-
-    - In **terminal #1**, run the `mkfiles` script to set up the network files
-      ```shell
-      # navigate to project root folder
-      cd $HOME/src/cardano-private-testnet-setup
-      
-      # run script file (note: it's important to run scripts from the root of the project as script paths are relative to the root)
-      ./scripts/mkfiles.sh
-      
-      # inspect script output
-      # If you see "Default yaml configuration applied." at the bottom, it was successful.
-      ```
-    - In the same **terminal #1**, start up the all three nodes using the script that gets generated by running make-network-files
-      ```shell
-      # for convenience, lets create a variable to store the name of the directory for our private testnet
-      # this directory was generated by running `./scripts/mkfiles.sh` above
-      ROOT=private-testnet
-        
-      # run script to start all three nodes.
-      ./$ROOT/run/all.sh
-      
-      # The output may show some Forge errors, but should go away once all the nodes are
-      # synched to each other  
-      ```
-
-   - Apply updates to the network to advance the network protocol to latest era and protocol version
-    
-        - Open **terminal #2** and run the `update-1` script
-          ```shell
-          # navigate to project root folder
-          cd $HOME/src/cardano-private-testnet-setup
-        
-          # set variables
-          ROOT=private-testnet
-          export CARDANO_NODE_SOCKET_PATH=$ROOT/node-bft1/node.sock
-          
-          # run script file
-          ./scripts/update-1.sh
-          
-          # if you see an error about `<socket> does not exist`, wait a little longer and try submitting the `scripts/update-1.sh` script again
-          ```
-        - In the same **terminal #2**, wait for at least the next epoch to make sure the update to protocol V1 is completed.
-          ```shell
-          
-          # run query to find out the current epoch
-          cardano-cli query tip --testnet-magic 42
-          
-          # the query should return something like this 
-          {
-            "epoch": 2,
-            "hash": "587799cb34f2c68a04c29204e120418351f4b449aa5286c9b4ac3244f30a7933",
-            "slot": 200,
-            "block": 197,
-            "era": "Byron",
-            "syncProgress": "100.00"
-          }    
-          ```
-        - In **terminal 2**, run the `update-2` script  
-          ```shell
-          ./scripts/update-2.sh
-          
-          # verify the transactions submitted successfully
-          # If you run the update script too early, you will see error regarding update proposal
-          # Just continue waiting until the next epoch is reached and try running the update again
-          ```
-        - Switch to **terminal 1** and restart the nodes
-          ```shell
-          # stop the script process
-          ctrl+c, ctrl+c  
-          # and run the script again to start up the nodes
-          ./$ROOT/run/all.sh  
-          ```
-        - In **terminal 2**, wait for a new epoch to make sure the update to protocol V2 is completed.
-          ```shell
-          # run query to find out the current epoch
-          cardano-cli query tip --testnet-magic 42
-          
-          # you should see something like this
-          {
-            "epoch": 3,
-            "hash": "d485e25f1287572ae75dbd35727ecd792595d88b66ac6e2144cbdf6dd1dab200",
-            "slot": 302,
-            "block": 290,
-            "era": "Byron",
-            "syncProgress": "100.00"
-          }
-          ```
-        - In **terminal 2**, run the v3 update script
-          ```shell  
-          ./scripts/update-3.sh <current_epoch>
-          
-          # verify the script update ran successfully
-          # if you see something like the following, it means you need to wait for another epoch
-          Command failed: transaction submit  Error: Error while submitting tx: ShelleyTxValidationError ShelleyBasedEraShelley (ApplyTxError [UtxowFailure (UtxoFailure (UpdateFailure (PPUpdateWrongEpoch (EpochNo 3) (EpochNo 3) VoteForNextEpoch)))])    
-          ```
-        - Switch to **terminal 1** and restart the nodes
-          ```shell
-          # stop the script process
-          ctrl+c, ctrl+c
-          
-          # run the script again to start up the nodes
-          ./$ROOT/run/all.sh  
-          ```
-        - In **terminal 2**, wait for at least the next epoch to make sure the update to protocol V3 is completed.
-          ```shell
-          # run query to find out the current epoch
-          cardano-cli query tip --testnet-magic 42
-          
-          # Starting in the Shelley era, we can also run query to get network protocol info
-          cardano-cli query protocol-parameters --testnet-magic 42
-          ```
-        - Repeat the same process as you did for `update-3` for each of `update-4`, `update-5`, and `update-6`
-        to advance the protocol updates to Alonzo era and protocol V6. These are the current era and protocol
-        at the time of this writing.
 ## 3. Verify the network state and wallet UTxO balances of user1
 
-- After completing the full set of updates, verify the era, major protocol version, and utxo balances of user1 address
+- After completing the full set of updates, verify the era and utxo balances of user1 address
   ```shell
   # if necessary, set variables
   ROOT=private-testnet
@@ -191,10 +60,6 @@ which means you can restart the nodes whenever you like, and your private testne
   cardano-cli query tip --testnet-magic 42 | jq '.era'
   #output
   "Alonzo"
-  
-  cardano-cli query protocol-parameters --testnet-magic 42 | jq '.protocolVersion.major'
-  #output
-  6
   
   cardano-cli query utxo --address $(cat private-testnet/addresses/user1.addr) --testnet-magic 42
   #output

--- a/4-ATTACH_DB_SYNC.md
+++ b/4-ATTACH_DB_SYNC.md
@@ -1,60 +1,34 @@
 # Attach db-sync process to the private network
-## Note: Please skip running this guide until an issue is fixed
-
-A recent change to the `cardano-db-sync` project source code leads to a validation failure when trying to
-attach the db-sync process to the private testnet. The author has logged an issue to find out how to resolve:
-[logged cardano-db-sync issue](https://github.com/input-output-hk/cardano-db-sync/issues/1046).
 
 ---
+**Note**: If you have not installed `cardano-db-sync`, then you should skip this guide and continue to next guide: [5. Run transaction](5-RUN_TRANSACTION.md)
+This guide covers attaching the `cardano-db-sync` process to the private testnet.  Doing so causes the blockchain data to
+be written to a highly normalized database schema in PostgresSQL database.  Then, it's possible to run SQL queries against the data
+for easy retrieval of information.
 
-[comment]: <> (**Note**: If you have not installed `cardano-db-sync`, then you should skip this guide and continue to next guide: [5. Run transaction]&#40;5-RUN_TRANSACTION.md&#41;)
+#### Assumptions
 
-[comment]: <> (This guide covers attaching the `cardano-db-sync` process to the private testnet.  Doing so causes the blockchain data to)
+- This guide assumes you are running a recent version of linux.
+  Specifically, these directions apply to Ubuntu (Debian). If you are using a different linux variant, please adjust as needed
+- Before using this guide, you should have completed the [Install executables guide](./1-INSTALL_EXECUTABLES.md) and
+  [Install PostgreSQL guide](2-INSTALL_POSTGRESQL.md).
 
-[comment]: <> (be written to a highly normalized database schema in PostgresSQL database.  Then, it's possible to run SQL queries against the data)
+## Run the script to start up the cardano-db-sync process
 
-[comment]: <> (for easy retrieval of information.)
+- Make sure the nodes are running
+- If necessary, please modify the `SCHEMA_DIR` environment variable below based on the location of your cloned copy of cardano-db-sync project
+- In **terminal 3**, start the db sync process.  This will install the database schema and sync blockchain data to the Postgres database.
+  ```shell
+  # navigate to project root folder
+  cd $HOME/src/cardano-private-testnet-setup
+  # set environment variable needed by `./scripts/db-sync-start.sh`
+  export SCHEMA_DIR=$HOME/src/cardano-db-sync/schema  
+  # run script file
+  ./scripts/db-sync-start.sh  
+  # output
+  # verify the output does not show any errors
+  # in a steady state, you should see logs of SQL insert statements into slot_leader and block tables   
+  ```
+---
 
-[comment]: <> (#### Assumptions)
-
-[comment]: <> (- This guide assumes you are running a recent version of linux.)
-
-[comment]: <> (  Specifically, these directions apply to Ubuntu &#40;Debian&#41;. If you are using a different linux variant, please adjust as needed)
-
-[comment]: <> (- Before using this guide, you should have completed the [Install executables guide]&#40;./1-INSTALL_EXECUTABLES.md&#41; and)
-
-[comment]: <> (  [Install PostgreSQL guide]&#40;2-INSTALL_POSTGRESQL.md&#41;.)
-
-[comment]: <> (## 1. Run the script to start up the cardano-db-sync process)
-
-[comment]: <> (- Make sure the nodes are running)
-
-[comment]: <> (- If necessary, please modify the `SCHEMA_DIR` environment variable below based on the location of your cloned copy of cardano-db-sync project)
-
-[comment]: <> (- In **terminal 3**, start the db sync process.  This will install the database schema and sync blockchain data to the Postgres database.)
-
-[comment]: <> (  ```shell)
-
-[comment]: <> (  # navigate to project root folder)
-
-[comment]: <> (  cd $HOME/src/cardano-private-testnet-setup)
-  
-[comment]: <> (  # set environment variable needed by `./scripts/db-sync-start.sh`)
-
-[comment]: <> (  export SCHEMA_DIR=$HOME/src/cardano-db-sync/schema)
-  
-[comment]: <> (  # run script file)
-
-[comment]: <> (  ./scripts/db-sync-start.sh)
-  
-[comment]: <> (  # output)
-
-[comment]: <> (  # verify the output does not show any errors)
-
-[comment]: <> (  # in a steady state, you should see logs of SQL insert statements into slot_leader and block tables   )
-
-[comment]: <> (  ```)
-
-[comment]: <> (---)
-
-[comment]: <> (Continue to next guide: [5. Run transaction]&#40;5-RUN_TRANSACTION.md&#41;)
+Continue to next guide: [5. Run transaction](5-RUN_TRANSACTION.md)

--- a/5-RUN_TRANSACTION.md
+++ b/5-RUN_TRANSACTION.md
@@ -48,7 +48,7 @@ looks like in the `cardano-db-sync` schema.
   ```shell
   cardano-cli query protocol-parameters \
   --testnet-magic 42 \
-  --out-file "protocol-parameters.json"
+  --out-file protocol-parameters.json
   ```
 - set `TXIN` variable with first utxo from user1.addr
   ```shell
@@ -107,80 +107,44 @@ looks like in the `cardano-db-sync` schema.
   
   ```
 
-[comment]: <> (## 3. Query the db-sync schema &#40;assuming you have set up db-sync&#41;)
+## 3. Query the db-sync schema (assuming you have set up db-sync)
 
-[comment]: <> (- open a psql prompt)
-
-[comment]: <> (  ```shell)
-
-[comment]: <> (  # set the postgres env. variable)
-
-[comment]: <> (  export PGPASSFILE=postgres-conn/pgpass-privatenet)
-  
-[comment]: <> (  # log-in to the privatenet database with our linux account)
-
-[comment]: <> (  psql -d privatenet)
-  
-[comment]: <> (  # sample output)
-
-[comment]: <> (  psql &#40;13.4 &#40;Ubuntu 13.4-0ubuntu0.21.04.1&#41;&#41;)
-
-[comment]: <> (  Type "help" for help.)
-
-[comment]: <> (  privatenet=#)
-
-[comment]: <> (  ```)
-
-[comment]: <> (- run queries in the psql editor)
-
-[comment]: <> (  ```shell)
-
-[comment]: <> (  # query transaction table and find id of the transaction we submitted above, i.e. one with max block_id)
-
-[comment]: <> (  select tx.id from tx where tx.block_id = &#40;select max &#40;tx.block_id&#41; from tx&#41;;)
-  
-[comment]: <> (  # sample output  )
-
-[comment]: <> (  id)
-
-[comment]: <> (  ----)
-
-[comment]: <> (  9)
-
-[comment]: <> (  &#40;1 row&#41;)
-
-[comment]: <> (  # query the fee amount for the transaction)
-
-[comment]: <> (  select tx.fee from tx where tx.id = 9;)
-  
-[comment]: <> (  # sample output)
-
-[comment]: <> (  fee   )
-
-[comment]: <> (  ---------)
-
-[comment]: <> (  1000000)
-
-[comment]: <> (  &#40;1 row&#41;)
-  
-[comment]: <> (  # query the transaction outputs related to the transaction)
-
-[comment]: <> (  select tx_out.id, tx_out.tx_id, tx_out.index, tx_out.address, tx_out.value )
-
-[comment]: <> (    from tx_out inner join tx on tx_out.tx_id = tx.id where tx.id = 9;)
-  
-[comment]: <> (  # sample output)
-
-[comment]: <> (  id | tx_id | index |                                                   address                                                    |   value   )
-
-[comment]: <> (  ----+-------+-------+--------------------------------------------------------------------------------------------------------------+-----------)
-
-[comment]: <> (  13 |     9 |     0 | addr_test1qzj7xja5rrly33z570ukrq7ayd3amf24k77v4dhu96fyal0vsegs7g7vwzwnrspq4eysyr66sc0wcv2xdtpau68m5qvqxhnvc5 |   5000000)
-
-[comment]: <> (  14 |     9 |     1 | addr_test1qp6h5v5ysaa0uqmhsmmu3gr8nhsf4w3st95p0vvvp4ldzn7esqup0hdw7rsuuhcyk0qrrvfp2yr4vtxhh0276yrcpmqqanu7lp | 494000000)
-
-[comment]: <> (  &#40;2 rows&#41;)
-
-[comment]: <> (  ```)
+- open a psql prompt
+  ```shell
+  # set the postgres env. variable
+  export PGPASSFILE=postgres-conn/pgpass-privatenet
+  # log-in to the privatenet database with our linux account
+  psql -d privatenet
+  # sample output
+  psql (13.4 (Ubuntu 13.4-0ubuntu0.21.04.1))
+  Type "help" for help.
+  privatenet=#
+  ```
+- run queries in the psql editor
+  ```shell
+  # query transaction table and find id of the transaction we submitted above, i.e. one with max block_id
+  select tx.id from tx where tx.block_id = (select max (tx.block_id) from tx);
+  # sample output  
+  id
+  ----
+  9
+  (1 row)
+  # query the fee amount for the transaction
+  select tx.fee from tx where tx.id = 9;
+  # sample output
+  fee   
+  ---------
+  1000000
+  (1 row)
+  # query the transaction outputs related to the transaction
+  select tx_out.id, tx_out.tx_id, tx_out.index, tx_out.address, tx_out.value 
+    from tx_out inner join tx on tx_out.tx_id = tx.id where tx.id = 9;
+  # sample output
+  id | tx_id | index |                                                   address                                                    |   value   
+  ----+-------+-------+--------------------------------------------------------------------------------------------------------------+-----------
+  13 |     9 |     0 | addr_test1qzj7xja5rrly33z570ukrq7ayd3amf24k77v4dhu96fyal0vsegs7g7vwzwnrspq4eysyr66sc0wcv2xdtpau68m5qvqxhnvc5 |   5000000
+  14 |     9 |     1 | addr_test1qp6h5v5ysaa0uqmhsmmu3gr8nhsf4w3st95p0vvvp4ldzn7esqup0hdw7rsuuhcyk0qrrvfp2yr4vtxhh0276yrcpmqqanu7lp | 494000000
+  (2 rows)
+  ```
 
 Continue to next guide: [6. Run Plutus script transactions](6-RUN_PLUTUS_SCRIPT_TXS.md)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@
 This project provides instructions and shell scripts to bootstrap a private Cardano testnet and connect a `cardano-db-sync` process to it.
 If you don't want to bother with setting up `cardano-db-sync`, you can easily skip over the sections of this project that are not relevant.
 
----
-**Note about cardano-db-sync:**
-
-There were some recent changes made to the `cardano-db-sync` sources that cause an issue when trying to attach the
-db-sync process to the private testnet.  The author has logged an issue for this: [issue](https://github.com/input-output-hk/cardano-db-sync/issues/1046).
-Please skip any guide instructions having to do with setting up/running `cardano-db-sync` until the issue is resolved.
----
-
 The scripts used by this project to create the private Cardano testnet are taken from the IOHK `cardano-node` project and have been modified as needed.
 You may find the original script files in the IOHK git repository: [cardano-node scripts](https://github.com/input-output-hk/cardano-node/tree/master/scripts/byron-to-alonzo).
 In particular, running `cardano-db-sync` to sync to the private testnet required a few changes to the original scripts provided by IOHK.
@@ -64,9 +56,9 @@ For an additional overview of this project, please check out this [medium articl
     * The `cardano-db-sync` process uses a connection to a PostgreSQL database.
     * Please refer to the [Install posgreSQL](2-INSTALL_POSTGRESQL.md) for instructions to set up.
 
-3. **Run scripts to set up & run private Cardano network and optionally connect DB Sync process**
+3. **Run scripts to set up & run private Cardano network**
 
-    * Run scripts to bootstrap the Cardano private network and attach the `cardano-db-sync` process to it to sync blockchain data to SQL database.
+    * Run scripts to bootstrap the Cardano private network
     * Please refer to the [Run network scripts guide](3-RUN_NETWORK_SCRIPTS.md) for instructions. 
 
 4. **Optional: Attach DB Sync process the network**
@@ -76,7 +68,7 @@ For an additional overview of this project, please check out this [medium articl
 
 5. **Run simple transaction and optionally query the db-sync database to see results**
 
-    * Set up a new walllet for user2 and make a payment from user1 to user2. Query the database to confirm the transaction.
+    * Set up a new wallet for user2 and make a payment from user1 to user2. Query the database to confirm the transaction.
     * Please refer to the [Run transaction guide](5-RUN_TRANSACTION.md) for instructions.
 
 6. **Run Plutus script transactions**


### PR DESCRIPTION
I finally got around to including instructions for installing `cardano-db-sync` with cherry-pick commits.  Then, I could restore the directions having to do with database.