### PR TITLE
Fix mkfiles.sh scripts

### DIFF
--- a/scripts/mkfiles.sh
+++ b/scripts/mkfiles.sh
@@ -318,11 +318,12 @@ echo "====================================================================="
 mkdir shelley
 
 # Copy the QA testnet alonzo genesis which is equivalent to the mainnet
+cp ../configuration/cardano/shelley_qa-alonzo-genesis.json shelley/genesis.alonzo.spec.json
 
 cardano-cli genesis create --testnet-magic ${NETWORK_MAGIC} --start-time $START_TIME_UTC --genesis-dir shelley
 
 # Then edit the genesis.spec.json ...
-cp ../configuration/cardano/shelley_qa-alonzo-genesis.json shelley/genesis.alonzo.spec.json
+#
 # We're going to use really quick epochs (300 seconds), by using short slots 0.2s
 # and K=10, but we'll keep long KES periods so we don't have to bother
 # cycling KES keys


### PR DESCRIPTION
Problem:

```shell
$ ./scripts/automate.sh
send kill signal for each running node PID
wait until running node count is 0
running node count is 0
~/src/cardano-private-testnet-setup/private-testnet ~/src/cardano-private-testnet-setup
=====================================================================
Generated genesis keys and genesis files:

byron/address-000
byron/address-001
byron/delegate-keys.000.key
byron/delegate-keys.001.key
byron/delegation-cert.000.json
byron/delegation-cert.001.json
byron/genesis-address-000
byron/genesis-address-001
byron/genesis.json
byron/genesis-keys.000.key
byron/genesis-keys.001.key
byron/genesis.spec.json
byron/payment-keys.000.key
byron/payment-keys.001.key
=====================================================================
Command failed: genesis create  Error: shelley/genesis.alonzo.spec.json: shelley/genesis.alonzo.spec.json: openBinaryFile: does not exist (No such file or directory)
```